### PR TITLE
グループ編集画面　改修

### DIFF
--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -25,15 +25,18 @@
       %label.chat-group-form__label チャットメンバー
     .chat-group-form__field--right#add-member
 
+      .chat-group-user.clearfix
+        %input{name: 'group[user_ids][]', type: 'hidden', value: current_user.id}
+        .chat-group-user__name
+          = current_user.name
+
       - group.users.each do |user|
-        .chat-group-user.clearfix{id: "chat-group-user-#{ user.id }"}
-          %input{name: 'group[user_ids][]', type: 'hidden', value: user.id}       
-          .chat-group-user__name
-            = user.name
-          -# グループ作成者じゃなければ
+        - if current_user.name != user.name
+          .chat-group-user.clearfix{id: "chat-group-user-#{ user.id }"}
+            %input{name: 'group[user_ids][]', type: 'hidden', value: user.id}
+            .chat-group-user__name
+              = user.name
             .chat-group-user__btn.chat-group-user__btn--remove 削除
-
-
 
   .chat-group-form__field.clearfix
     .chat-group-form__field--left


### PR DESCRIPTION
＃What
グループ編集画面にてグループを作成したユーザー(current_user)にも「削除」が表示されてしまうので、表示されないようにする

＃Why
作成したユーザーやログインしているユーザーが他社からも削除されてしまうから

[![Screenshot from Gyazo](https://gyazo.com/189b2e3dec84c299ad36d07839e2944d/raw)](https://gyazo.com/189b2e3dec84c299ad36d07839e2944d)

[![Screenshot from Gyazo](https://gyazo.com/a6124b8f07e9ab4afb600d33300b053c/raw)](https://gyazo.com/a6124b8f07e9ab4afb600d33300b053c)