### PR TITLE
Saveボタンの調整

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def index
-      @users = User.where('name LIKE(?)', "%#{params[:name]}%").where.not(id: current_user.id)
+      @users = User.where('name LIKE(?)', "%#{params[:name]}%").where.not(id: current_user.id).where.not(id: params[:user_ids])
       respond_to do |format|
           format.html
           format.json

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -29,6 +29,7 @@
         %input{name: 'group[user_ids][]', type: 'hidden', value: current_user.id}
         .chat-group-user__name
           = current_user.name
+        -# .chat-group-user__btn.chat-group-user__btn--add 追加
 
       - group.users.each do |user|
         - if current_user.name != user.name

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,7 @@ module ChatSpace
         g.helper false
         g.test_framework false
       end
+    config.action_view.automatically_disable_submit_tag = false
     config.i18n.default_locale = :ja
     config.time_zone = 'Tokyo'
   end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -142,9 +142,9 @@ ja:
     select:
       prompt: 選択してください
     submit:
-      create: 登録する
+      create: Save
       submit: 保存する
-      update: 更新する
+      update: Save
   number:
     currency:
       format:


### PR DESCRIPTION
グループ編集のページでメンバを追加し、「Save」ボタンをクリックすると一瞬「更新する」と変化する。(edit)

新規登録画面では、新しいメンバーを追加するときに「Save」ボタンをクリックすると一瞬「登録する」と変化する。(new)


調査：
検索する、Saveボタンをクリックする。
<input type="submit" name="commit" value="Save" class="chat-group-form__action-btn" data-disable-with="更新する">

<input type="submit" name="commit" value="Save" class="chat-group-form__action-btn" data-disable-with="登録する">

仮説：
　　　１　　data-disable-withが怪しい。
　　　　　　data-disable-withはhamlだが、HTML（検索時、RailsのView)
　　　　　　コンパイル作業をする。

　　　２　　根幹設定をしているのは、大体がConfig/application.rb
　　　　　　Config/application.rbファイル：
　　　　　　 require 'rails/all'

　　　　（ファイル内）

require_relative 'boot'
 require 'rails/all'

  　# Require the gems listed in Gemfile, including any gems
　# you've limited to :test, :development, or :production.
Bundler.require(*Rails.groups)

module ChatSpace
  class Application < Rails::Application
      config.generators do |g|
        g.stylesheets false
        g.javascripts false
        g.helper false　　　　　　（←ここをみる）
        g.test_framework false
      end
    config.action_view.automatically_disable_submit_tag = false
    config.i18n.default_locale = :ja
    config.time_zone = 'Tokyo'
  end
end


　　　３　　edit「更新する」、newは「登録する」となるので、この二つは連動する。


作業：
data-disable-withを消去する。
消去してみると「Save」の文字列が消える。

JaveScript上で何かあるか探してみる。(例: users.js, 〜js)



原因：
config/ local/ !ja.yml

  helpers:
    select:
      prompt: 選択してください
    submit:
      create: Save
      submit: 保存する
      update: Save

create:　更新する　　　となっていたので　updete: Save　に変更する。

create: Save
subumit: 保存する
update: Save

EditとNewのページでのSaveボタンの挙動は連動しているので、ここでコードを正す。


[![Screenshot from Gyazo](https://gyazo.com/1bec646bf76a9eb97dc4d0ff887c3941/raw)](https://gyazo.com/1bec646bf76a9eb97dc4d0ff887c3941)







