### PR TITLE
Saveボタンの調整2

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def index
-      @users = User.where('name LIKE(?)', "%#{params[:name]}%").where.not(id: current_user.id).where.not(id: params[:user_ids])
+      @users = User.where('name LIKE(?)', "%#{params[:name]}%").where.not(id: current_user.id)
       respond_to do |format|
           format.html
           format.json

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -29,7 +29,6 @@
         %input{name: 'group[user_ids][]', type: 'hidden', value: current_user.id}
         .chat-group-user__name
           = current_user.name
-        -# .chat-group-user__btn.chat-group-user__btn--add 追加
 
       - group.users.each do |user|
         - if current_user.name != user.name

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,6 @@ module ChatSpace
         g.helper false
         g.test_framework false
       end
-    config.action_view.automatically_disable_submit_tag = false
     config.i18n.default_locale = :ja
     config.time_zone = 'Tokyo'
   end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -142,9 +142,9 @@ ja:
     select:
       prompt: 選択してください
     submit:
-      create: 登録する
+      create: save
       submit: 保存する
-      update: 更新する
+      update: save
   number:
     currency:
       format:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -142,9 +142,9 @@ ja:
     select:
       prompt: 選択してください
     submit:
-      create: Save
+      create: 登録する
       submit: 保存する
-      update: Save
+      update: 更新する
   number:
     currency:
       format:


### PR DESCRIPTION
#what
Saveボタンを調整する

#why
グループ編集のSaveボタンと新規登録画面のSaveボタンをクリックすると一瞬、「更新する」「登録する」とそれぞれ表示されるからそれらを改修する。

調査：
検索する、Saveボタンをクリックする。
仮説：
　　　１　　data-disable-withが怪しい。
　　　　　　data-disable-withはhamlだが、HTML（検索時、RailsのView)
　　　　　　コンパイル作業をする。

　　　２　　根幹設定をしているのは、大体がConfig/application.rb
　　　　　　Config/application.rbファイル：
　　　　　　 require 'rails/all'

　　　　（ファイル内）

require_relative 'boot'
require 'rails/all'

　# Require the gems listed in Gemfile, including any gems
　# you've limited to :test, :development, or :production.
Bundler.require(*Rails.groups)

module ChatSpace
class Application < Rails::Application
config.generators do |g|
g.stylesheets false
g.javascripts false
g.helper false　　　　　　（←ここをみる）
g.test_framework false
end
config.action_view.automatically_disable_submit_tag = false
config.i18n.default_locale = :ja
config.time_zone = 'Tokyo'
end
end

　　　３　　edit「更新する」、newは「登録する」となるので、この二つは連動する。

作業：
data-disable-withを消去する。
消去してみると「Save」の文字列が消える。

JaveScript上で何かあるか探してみる。(例: users.js, 〜js)

原因：
config/ local/ !ja.yml

helpers:
select:
prompt: 選択してください
submit:
create: Save
submit: 保存する
update: Save

create:　更新する　　　となっていたので　updete: Save　に変更する。

create: Save
subumit: 保存する
update: Save

EditとNewのページでのSaveボタンの挙動は連動しているので、ここでコードを正す。

[![Screenshot from Gyazo](https://gyazo.com/4e4f8ee38b9ea0884e66e446cbb8b934/raw)](https://gyazo.com/4e4f8ee38b9ea0884e66e446cbb8b934)