### PR TITLE
既存のuserの追加表示改修

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,17 @@ class UsersController < ApplicationController
   end
 
   def update
+    if current_user.update(user_params)
+      redirect_to root_path
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email)
   end
 end
 


### PR DESCRIPTION
#what
users.conntrollerのupdate （リソースを更新する）と　privateの記述がなかった


#why
users.conntrollerのupdate （リソースを更新する）と　privateの記述をすることでuserの名前の変更時にエラーなならない。