### PR TITLE
_chat_side.scssの改修１

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 ### Association
 - has_many :members
 - has_many :messages
-- has_many :groups, throuh::members
+- has_many :groups, through::members
 
 
 
@@ -53,7 +53,7 @@
 |body|text|nill: false|
 
 ### Association
-- has_many: users throuh::members
+- has_many: users through::members
 - has_many: members
 - has_many: messages
 

--- a/app/assets/stylesheets/_chat-side.scss
+++ b/app/assets/stylesheets/_chat-side.scss
@@ -8,6 +8,8 @@
     height: 100px;
     line-height: 100px;
     padding: 0 20px;
+    display: flex;
+    justify-content: space-between;
     &__name{
       display: inline-block;
       font-size: $side_header_font;
@@ -15,14 +17,13 @@
       scroll-padding: 20px;
     }
     &__lists{
-      float: right;
       display: inline-block;
       .list{
         display: inline-block;
       }
       .icon{
         color: $white;
-      }    
+      }
     }
   }
   .groups{
@@ -37,15 +38,15 @@
       }
       &__name{
         color: $white;
-        font-size: $side_group_name;  
+        font-size: $side_group_name;
       }
       &__message{
         color: $white;
         font-size: $side_group_message;
-        margin-top: 5px; 
+        margin-top: 5px;
         margin-bottom: ５px;
         padding: 5px 0 40px;
-      } 
+      }
     }
-  }  
+  }
 }

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -10,17 +10,16 @@
         %ul.left-header__members
           %span.member__name
             Member:
-          %li.member      
-            - @group.users.each do |user|
-              = user.name   
           %li.member
-                         
-          %li.member 
-          
+            - @group.users.each do |user|
+              = user.name
+          %li.member
+
+          %li.member
+
       .right-header
-        = link_to 'Edit', edit_group_path(@group.id),class: 'right-header__button' 
-          
-            
+        = link_to 'Edit', edit_group_path(@group.id),class: 'right-header__button'
+
 
     .messages
       = render @messages


### PR DESCRIPTION
###WHAT
float-rightでエラーがVS-cordに出たがviewは崩れない。
新しい記述に直す


###Why
現在主流のjustify-content:    ;で改修
エラーがなくなった
